### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk: openjdk8
+branches:
+  only:
+  - master
+  - "/.*-[0-9]+\\..*/"
+install: true
+script: ".travis/build.sh"
+cache:
+  directories:
+  - "~/.m2/repository"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/travis-build.sh
+sh travis-build.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![](https://travis-ci.com/duderstadt-lab/mars-core.svg?branch=master)](https://travis-ci.com/duderstadt-lab/mars-core)
+
 <p><img src="https://raw.githubusercontent.com/duderstadt-lab/mars-docs/master/images/MARS%20front%20page.png" width=“800"></p>
 
 **MARS** - **M**olecule **AR**chive **S**uite - A collection of ImageJ2 commands for single-molecule analysis.

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 	</mailingLists>
 
 	<scm>
-		<connection>scm:git:git://github.com/duderstadt-lab/mars-core.git</connection>
-		<developerConnection>scm:git:git@github.com:duderstadt-lab/mars-core.git</developerConnection>
+		<connection>scm:git:git://github.com/duderstadt-lab/mars-core</connection>
+		<developerConnection>scm:git:git@github.com:duderstadt-lab/mars-core</developerConnection>
 		<tag>HEAD</tag>
 		<url>https://github.com/duderstadt-lab/mars-core</url>
 	</scm>
@@ -76,13 +76,17 @@
 		<url>https://github.com/duderstadt-lab/mars-core/issues</url>
 	</issueManagement>
 	<ciManagement>
-		<system>None</system>
+		<system>Travis CI</system>
+		<url>https://travis-ci.com/duderstadt-lab/mars-core</url>
 	</ciManagement>
 
 	<properties>
 		<package-name>de.mpg.biochem.mars</package-name>
 		<license.licenseName>BSD-2</license.licenseName>
 		<license.copyrightOwners>Karl Duderstadt</license.copyrightOwners>
+
+		<!-- NB: Deploy releases to the SciJava Maven repository. -->
+		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 	</properties>
 	
 	<repositories>


### PR DESCRIPTION
This adds everything necessary to build the project on Travis CI, and deploy resultant artifacts to maven.scijava.org.

It does _not_ add the configuration needed to sign the artifacts with GPG, such that they can be deployed to OSS Sonatype. For that, I would need temporary admin access to the repository, so that I can encrypt the GPG key; the [process](https://docs.travis-ci.com/user/encrypting-files/) needs to register a key/IV pair in the travis-ci.com settings.