### PR TITLE
Migrate S3 support from AWS SDK v1 to v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>44.0.0</version>
+		<version>45.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -230,8 +230,8 @@
 		    <scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-s3</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/src/main/java/de/mpg/biochem/mars/io/MoleculeArchiveAmazonS3KeyValueAccess.java
+++ b/src/main/java/de/mpg/biochem/mars/io/MoleculeArchiveAmazonS3KeyValueAccess.java
@@ -29,9 +29,10 @@
 
 package de.mpg.biochem.mars.io;
 
-import com.amazonaws.services.s3.AmazonS3;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -45,35 +46,45 @@ import java.nio.channels.NonReadableChannelException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.ListObjectsV2Request;
-import com.amazonaws.services.s3.model.ListObjectsV2Result;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 public class MoleculeArchiveAmazonS3KeyValueAccess {
-    private final AmazonS3 s3;
+    private final S3Client s3;
     private final String bucketName;
 
     /**
-     * Opens an {@link AmazonS3} client and a given bucket name.
+     * Opens an {@link S3Client} client and a given bucket name.
      *
      * @param s3 the s3 instance
      * @param bucketName the bucket name
      * @throws IOException if the access could not be created
      */
-    public MoleculeArchiveAmazonS3KeyValueAccess(final AmazonS3 s3, final String bucketName) throws IOException {
+    public MoleculeArchiveAmazonS3KeyValueAccess(final S3Client s3, final String bucketName) throws IOException {
 
         this.s3 = s3;
         this.bucketName = bucketName;
 
-        if (!s3.doesBucketExistV2(bucketName)) throw new IOException("Bucket " + bucketName + " does not exist.");
+        try {
+            s3.headBucket(HeadBucketRequest.builder().bucket(bucketName).build());
+        } catch (final NoSuchBucketException e) {
+            throw new IOException("Bucket " + bucketName + " does not exist.");
+        }
     }
 
     public String[] components(final String path) {
@@ -236,12 +247,13 @@ public class MoleculeArchiveAmazonS3KeyValueAccess {
      * @return {@code true} if {@code key} exists.
      */
     private boolean keyExists(final String key) {
-        final ListObjectsV2Request listObjectsRequest = new ListObjectsV2Request()
-                .withBucketName(bucketName)
-                .withPrefix(key)
-                .withMaxKeys(1);
-        final ListObjectsV2Result objectsListing = s3.listObjectsV2(listObjectsRequest);
-        return objectsListing.getKeyCount() > 0;
+        final ListObjectsV2Request listObjectsRequest = ListObjectsV2Request.builder()
+                .bucket(bucketName)
+                .prefix(key)
+                .maxKeys(1)
+                .build();
+        final ListObjectsV2Response objectsListing = s3.listObjectsV2(listObjectsRequest);
+        return objectsListing.keyCount() > 0;
     }
 
     /**
@@ -311,17 +323,19 @@ public class MoleculeArchiveAmazonS3KeyValueAccess {
     public List<String> listObjectKeys(final String normalPath) {
         final List<String> keys = new ArrayList<>();
         final String prefix = removeLeadingSlash(addTrailingSlash(normalPath));
-        final ListObjectsV2Request listObjectsRequest = new ListObjectsV2Request()
-                .withBucketName(bucketName)
-                .withPrefix(prefix)
-                .withDelimiter("/");
-        ListObjectsV2Result objectsListing;
+        String continuationToken = null;
+        ListObjectsV2Response objectsListing;
         do {
-            objectsListing = s3.listObjectsV2(listObjectsRequest);
-            for (final S3ObjectSummary objectSummary : objectsListing.getObjectSummaries()) {
-                keys.add(objectSummary.getKey());
+            objectsListing = s3.listObjectsV2(ListObjectsV2Request.builder()
+                    .bucket(bucketName)
+                    .prefix(prefix)
+                    .delimiter("/")
+                    .continuationToken(continuationToken)
+                    .build());
+            for (final S3Object objectSummary : objectsListing.contents()) {
+                keys.add(objectSummary.key());
             }
-            listObjectsRequest.setContinuationToken(objectsListing.getNextContinuationToken());
+            continuationToken = objectsListing.nextContinuationToken();
         } while (objectsListing.isTruncated());
         return keys;
     }
@@ -333,17 +347,19 @@ public class MoleculeArchiveAmazonS3KeyValueAccess {
     private String[] list(final String normalPath, final boolean onlyDirectories) {
         final List<String> items = new ArrayList<>();
         final String prefix = removeLeadingSlash(addTrailingSlash(normalPath));
-        final ListObjectsV2Request listObjectsRequest = new ListObjectsV2Request()
-                .withBucketName(bucketName)
-                .withPrefix(prefix)
-                .withDelimiter("/");
-        ListObjectsV2Result objectsListing;
+        String continuationToken = null;
+        ListObjectsV2Response objectsListing;
         do {
-            objectsListing = s3.listObjectsV2(listObjectsRequest);
-            for (final String commonPrefix : objectsListing.getCommonPrefixes()) items.add(lastGroupName(commonPrefix));
+            objectsListing = s3.listObjectsV2(ListObjectsV2Request.builder()
+                    .bucket(bucketName)
+                    .prefix(prefix)
+                    .delimiter("/")
+                    .continuationToken(continuationToken)
+                    .build());
+            for (final CommonPrefix commonPrefix : objectsListing.commonPrefixes()) items.add(lastGroupName(commonPrefix.prefix()));
             if (!onlyDirectories)
-                for (final S3ObjectSummary objectSummary : objectsListing.getObjectSummaries()) items.add(lastGroupName(objectSummary.getKey()));
-            listObjectsRequest.setContinuationToken(objectsListing.getNextContinuationToken());
+                for (final S3Object objectSummary : objectsListing.contents()) items.add(lastGroupName(objectSummary.key()));
+            continuationToken = objectsListing.nextContinuationToken();
         } while (objectsListing.isTruncated());
         return items.toArray(new String[items.size()]);
     }
@@ -366,148 +382,71 @@ public class MoleculeArchiveAmazonS3KeyValueAccess {
             if (path.equals("/")) {
                 continue;
             }
-            final ObjectMetadata metadata = new ObjectMetadata();
-            metadata.setContentLength(0);
             s3.putObject(
-                    bucketName,
-                    path,
-                    new ByteArrayInputStream(new byte[0]),
-                    metadata);
+                    PutObjectRequest.builder().bucket(bucketName).key(path).build(),
+                    RequestBody.fromBytes(new byte[0]));
         }
     }
 
     public void delete(final String normalPath) throws IOException {
 
-        if (!s3.doesBucketExistV2(bucketName))
+        try {
+            s3.headBucket(HeadBucketRequest.builder().bucket(bucketName).build());
+        } catch (final NoSuchBucketException e) {
             return;
+        }
 
         // remove bucket when deleting "/"
         if (normalPath.equals(normalize("/"))) {
 
             // need to delete all objects before deleting the bucket
             // see: https://docs.aws.amazon.com/AmazonS3/latest/userguide/delete-bucket.html
-            ObjectListing objectListing = s3.listObjects(bucketName);
-            while (true) {
-                final Iterator<S3ObjectSummary> objIter = objectListing.getObjectSummaries().iterator();
-                while (objIter.hasNext()) {
-                    s3.deleteObject(bucketName, objIter.next().getKey());
-                }
+            String continuationToken = null;
+            ListObjectsV2Response objectsListing;
+            do {
+                objectsListing = s3.listObjectsV2(ListObjectsV2Request.builder()
+                        .bucket(bucketName)
+                        .continuationToken(continuationToken)
+                        .build());
+                for (final S3Object object : objectsListing.contents())
+                    s3.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(object.key()).build());
+                continuationToken = objectsListing.nextContinuationToken();
+            } while (objectsListing.isTruncated());
 
-                // If the bucket contains many objects, the listObjects() call
-                // might not return all of the objects in the first listing. Check to
-                // see whether the listing was truncated. If so, retrieve the next page of objects
-                // and delete them.
-                if (objectListing.isTruncated()) {
-                    objectListing = s3.listNextBatchOfObjects(objectListing);
-                } else {
-                    break;
-                }
-            }
-
-            s3.deleteBucket(bucketName);
+            s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build());
             return;
         }
 
         final String path = removeLeadingSlash(normalPath);
 
         if (!path.endsWith("/")) {
-            s3.deleteObjects(new DeleteObjectsRequest(bucketName)
-                    .withKeys(new String[]{path}));
+            s3.deleteObjects(DeleteObjectsRequest.builder()
+                    .bucket(bucketName)
+                    .delete(Delete.builder().objects(ObjectIdentifier.builder().key(path).build()).build())
+                    .build());
         }
 
         final String prefix = addTrailingSlash(path);
-        final ListObjectsV2Request listObjectsRequest = new ListObjectsV2Request()
-                .withBucketName(bucketName)
-                .withPrefix(prefix);
-        ListObjectsV2Result objectsListing;
+        String continuationToken = null;
+        ListObjectsV2Response objectsListing;
         do {
-            objectsListing = s3.listObjectsV2(listObjectsRequest);
-            final List<String> objectsToDelete = new ArrayList<>();
-            for (final S3ObjectSummary object : objectsListing.getObjectSummaries())
-                objectsToDelete.add(object.getKey());
+            objectsListing = s3.listObjectsV2(ListObjectsV2Request.builder()
+                    .bucket(bucketName)
+                    .prefix(prefix)
+                    .continuationToken(continuationToken)
+                    .build());
+            final List<ObjectIdentifier> objectsToDelete = new ArrayList<>();
+            for (final S3Object object : objectsListing.contents())
+                objectsToDelete.add(ObjectIdentifier.builder().key(object.key()).build());
 
             if (!objectsToDelete.isEmpty()) {
-                s3.deleteObjects(new DeleteObjectsRequest(bucketName)
-                        .withKeys(objectsToDelete.toArray(new String[objectsToDelete.size()])));
+                s3.deleteObjects(DeleteObjectsRequest.builder()
+                        .bucket(bucketName)
+                        .delete(Delete.builder().objects(objectsToDelete).build())
+                        .build());
             }
-            listObjectsRequest.setContinuationToken(objectsListing.getNextContinuationToken());
+            continuationToken = objectsListing.nextContinuationToken();
         } while (objectsListing.isTruncated());
-    }
-
-    /**
-     * Helper class that drains the rest of the {@link S3ObjectInputStream} on {@link #close()}.
-     *
-     * Without draining the stream AWS S3 SDK sometimes outputs the following warning message:
-     * "... Not all bytes were read from the S3ObjectInputStream, aborting HTTP connection ...".
-     *
-     * Draining the stream helps to avoid this warning and possibly reuse HTTP connections.
-     *
-     * Calling {@link S3ObjectInputStream#abort()} does not prevent this warning as discussed here:
-     * https://github.com/aws/aws-sdk-java/issues/1211
-     */
-    private static class S3ObjectInputStreamDrain extends InputStream {
-
-        private final S3ObjectInputStream in;
-        private boolean closed;
-
-        public S3ObjectInputStreamDrain(final S3ObjectInputStream in) {
-
-            this.in = in;
-        }
-
-        @Override
-        public int read() throws IOException {
-
-            return in.read();
-        }
-
-        @Override
-        public int read(final byte[] b, final int off, final int len) throws IOException {
-
-            return in.read(b, off, len);
-        }
-
-        @Override
-        public boolean markSupported() {
-
-            return in.markSupported();
-        }
-
-        @Override
-        public void mark(final int readlimit) {
-
-            in.mark(readlimit);
-        }
-
-        @Override
-        public void reset() throws IOException {
-
-            in.reset();
-        }
-
-        @Override
-        public int available() throws IOException {
-
-            return in.available();
-        }
-
-        @Override
-        public long skip(final long n) throws IOException {
-
-            return in.skip(n);
-        }
-
-        @Override
-        public void close() throws IOException {
-
-            if (!closed) {
-                do {
-                    in.skip(in.available());
-                } while (read() != -1);
-                in.close();
-                closed = true;
-            }
-        }
     }
 
     private class S3ObjectChannel implements LockedChannel {
@@ -531,12 +470,12 @@ public class MoleculeArchiveAmazonS3KeyValueAccess {
 
         @Override
         public InputStream newInputStream() throws IOException {
-            final S3ObjectInputStream in = s3.getObject(bucketName, path).getObjectContent();
-            final S3ObjectInputStreamDrain s3in = new S3ObjectInputStreamDrain(in);
+            final ResponseInputStream<GetObjectResponse> in = s3.getObject(
+                    GetObjectRequest.builder().bucket(bucketName).key(path).build());
             synchronized (resources) {
-                resources.add(s3in);
+                resources.add(in);
             }
-            return s3in;
+            return in;
         }
 
         @Override
@@ -600,11 +539,9 @@ public class MoleculeArchiveAmazonS3KeyValueAccess {
                 if (!closed) {
                     closed = true;
                     final byte[] bytes = buf.toByteArray();
-                    final ObjectMetadata objectMetadata = new ObjectMetadata();
-                    objectMetadata.setContentLength(bytes.length);
-                    try (final InputStream data = new ByteArrayInputStream(bytes)) {
-                        s3.putObject(bucketName, path, data, objectMetadata);
-                    }
+                    s3.putObject(
+                            PutObjectRequest.builder().bucket(bucketName).key(path).build(),
+                            RequestBody.fromBytes(bytes));
                     buf.close();
                 }
             }

--- a/src/main/java/de/mpg/biochem/mars/io/MoleculeArchiveAmazonS3Source.java
+++ b/src/main/java/de/mpg/biochem/mars/io/MoleculeArchiveAmazonS3Source.java
@@ -29,8 +29,9 @@
 
 package de.mpg.biochem.mars.io;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3URI;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Uri;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -45,7 +46,7 @@ import java.net.UnknownHostException;
 import java.util.List;
 
 public class MoleculeArchiveAmazonS3Source implements MoleculeArchiveSource {
-    protected final AmazonS3 s3;
+    protected final S3Client s3;
     protected final String bucketName;
     protected String containerPath;
 
@@ -60,11 +61,11 @@ public class MoleculeArchiveAmazonS3Source implements MoleculeArchiveSource {
      * If the bucket does not exist, it will not be created and
      * all subsequent attempts to read attributes, groups, or datasets will fail.
      *
-     * @param s3 AmazonS3 location.
+     * @param s3 S3Client location.
      * @param bucketName the name of the bucket.
      * @throws IOException thrown when reading or writing to the location fails.
      */
-    public MoleculeArchiveAmazonS3Source(final AmazonS3 s3, final String bucketName) throws IOException {
+    public MoleculeArchiveAmazonS3Source(final S3Client s3, final String bucketName) throws IOException {
 
         this(s3, bucketName, "/");
     }
@@ -75,13 +76,14 @@ public class MoleculeArchiveAmazonS3Source implements MoleculeArchiveSource {
      * If the bucket and/or container does not exist, it will not be created and
      * all subsequent attempts to read attributes, groups, or datasets will fail.
      *
-     * @param s3 AmazonS3 location.
+     * @param s3 S3Client location.
      * @param containerURI the container uri.
      * @throws IOException thrown when reading or writing to the location fails.
      */
-    public MoleculeArchiveAmazonS3Source(final AmazonS3 s3, final AmazonS3URI containerURI) throws IOException {
+    public MoleculeArchiveAmazonS3Source(final S3Client s3, final S3Uri containerURI) throws IOException {
 
-        this(s3, containerURI.getBucket(), containerURI.getKey());
+        this(s3, containerURI.bucket().orElseThrow(() -> new IOException("No bucket specified in " + containerURI.uri())),
+                containerURI.key().orElse("/"));
     }
 
     /**
@@ -90,13 +92,13 @@ public class MoleculeArchiveAmazonS3Source implements MoleculeArchiveSource {
      * If the bucket and/or container does not exist, it will not be created and
      * all subsequent attempts to read attributes, groups, or datasets will fail.
      *
-     * @param s3 AmazonS3 location.
+     * @param s3 S3Client location.
      * @param bucketName the name of the bucket.
      * @param containerPath the object path within the bucket.
      * @throws IOException thrown when reading or writing to the location fails.
      */
     public MoleculeArchiveAmazonS3Source(
-            final AmazonS3 s3,
+            final S3Client s3,
             final String bucketName,
             final String containerPath) throws IOException {
 
@@ -152,7 +154,7 @@ public class MoleculeArchiveAmazonS3Source implements MoleculeArchiveSource {
 
     public boolean isReachable() {
         try{
-            URL url = s3.getUrl(bucketName,"/");
+            URL url = s3.utilities().getUrl(GetUrlRequest.builder().bucket(bucketName).key("/").build());
             HttpURLConnection connection = (HttpURLConnection)url.openConnection();
             connection.setRequestMethod("OPTIONS");
             connection.connect();

--- a/src/main/java/de/mpg/biochem/mars/io/MoleculeArchiveIOFactory.java
+++ b/src/main/java/de/mpg/biochem/mars/io/MoleculeArchiveIOFactory.java
@@ -34,15 +34,14 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.AmazonS3URI;
-import com.amazonaws.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Uri;
 
 public class MoleculeArchiveIOFactory {
 
@@ -52,25 +51,23 @@ public class MoleculeArchiveIOFactory {
      * @param endpoint
      * @return
      */
-    private static AmazonS3 createS3SourceWithEndpoint(final String endpoint) {
-        AmazonS3 s3;
-        AWSCredentials credentials = null;
+    private static S3Client createS3SourceWithEndpoint(final String endpoint) {
+        AwsCredentialsProvider credentialsProvider;
         try {
-            credentials = new DefaultAWSCredentialsProviderChain().getCredentials();
+            final AwsCredentials credentials = DefaultCredentialsProvider.create().resolveCredentials();
+            credentialsProvider = StaticCredentialsProvider.create(credentials);
         } catch(final Exception e) {
             System.out.println( "Could not load AWS credentials, falling back to anonymous." );
+            credentialsProvider = AnonymousCredentialsProvider.create();
         }
-        final AWSStaticCredentialsProvider credentialsProvider =
-                new AWSStaticCredentialsProvider(credentials == null ? new AnonymousAWSCredentials() : credentials);
 
         //US_EAST_2 is used as a dummy region.
-        s3 = AmazonS3ClientBuilder.standard()
-                .withPathStyleAccessEnabled(true)
-                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, Regions.US_EAST_2.getName()))
-                .withCredentials(credentialsProvider)
+        return S3Client.builder()
+                .forcePathStyle(true)
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.US_EAST_2)
+                .credentialsProvider(credentialsProvider)
                 .build();
-
-        return s3;
     }
 
     /**
@@ -82,9 +79,9 @@ public class MoleculeArchiveIOFactory {
      * @throws IOException the io exception
      */
     public MoleculeArchiveAmazonS3Source openAWSS3SourceWithEndpoint(final String s3Url, final String endpointUrl) throws IOException {
-        return new MoleculeArchiveAmazonS3Source(
-                createS3SourceWithEndpoint(endpointUrl),
-                new AmazonS3URI(s3Url));
+        final S3Client s3 = createS3SourceWithEndpoint(endpointUrl);
+        final S3Uri containerURI = s3.utilities().parseUri(URI.create(s3Url));
+        return new MoleculeArchiveAmazonS3Source(s3, containerURI);
     }
 
     /**


### PR DESCRIPTION
## Summary
- The pom's AWS S3 dependency changed from `com.amazonaws:aws-java-sdk-s3` (v1) to `software.amazon.awssdk:s3` (v2, managed by pom-scijava 45.0.0), but `MoleculeArchiveIOFactory`, `MoleculeArchiveAmazonS3Source`, and `MoleculeArchiveAmazonS3KeyValueAccess` still used v1 classes (`AmazonS3`, `AmazonS3URI`, `AWSCredentials`, `ObjectMetadata`, etc.), causing `NoClassDefFoundError: com/amazonaws/auth/AWSCredentials` at runtime -- even for local filesystem archives, since `MoleculeArchiveIOPlugin.open()` unconditionally instantiates `MoleculeArchiveIOFactory`.
- Ports all three classes to the AWS SDK v2 API: `S3Client` replaces `AmazonS3`, `S3Uri`/`S3Utilities` replace `AmazonS3URI`, `DefaultCredentialsProvider`/`AnonymousCredentialsProvider` replace the v1 credential provider chain, and all list/put/delete/head calls move to the v2 builder-based request/response objects.
- Removed the `S3ObjectInputStreamDrain` workaround class -- it existed to avoid a v1-specific "unconsumed bytes" warning; v2's `ResponseInputStream` doesn't have that issue.

## Test plan
- [x] `mvn -o compile` -- clean build
- [x] `mvn -o test -Dtest=MoleculeArchiveTests` -- 8/8 pass (previously failing with `NoClassDefFoundError`)
- [x] `mvn -o test` (full suite) -- 99/99 pass

Note: mars-fx still references `com.amazonaws.AmazonServiceException` in a few S3 dialog files, currently compiling only via a transitive v1 dependency from `n5-aws-s3`. That will need its own follow-up once mars-fx picks up this mars-core version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)